### PR TITLE
Fixes copy & paste error with learning rates

### DIFF
--- a/torch_models.py
+++ b/torch_models.py
@@ -70,21 +70,21 @@ class CustomModel():
         
         if build_info['optimizer']['val'] == 'adam':
             optimizer = optim.Adam(self.model.parameters(),
-                                lr=build_info['weight_decay']['val'],
+                                lr=build_info['lr']['val'],
                                 weight_decay=build_info['weight_decay']['val'])
 
         elif build_info['optimizer']['val'] == 'adadelta':
             optimizer = optim.Adadelta(self.model.parameters(),
-                                    lr=build_info['weight_decay']['val'],
+                                    lr=build_info['lr']['val'],
                                     weight_decay=build_info['weight_decay']['val'])
 
         elif build_info['optimizer']['val'] == 'rmsprop':
             optimizer = optim.RMSprop(self.model.parameters(),
-                                    lr=build_info['weight_decay']['val'],
+                                    lr=build_info['lr']['val'],
                                     weight_decay=build_info['weight_decay']['val'])
         else:
             optimizer = optim.SGD(self.model.parameters(),
-                                lr=build_info['weight_decay']['val'],
+                                lr=build_info['lr']['val'],
                                 weight_decay=build_info['weight_decay']['val'],
                                 momentum=0.9)
         self.optimizer = optimizer


### PR DESCRIPTION
The optimizers were using the `weight_decay` key from the `build_info` dict for the learning rates.